### PR TITLE
update run script to work better from other dirs

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,6 @@
 # ./run.sh --inventory ~/my_inventory --limit kvmhost,guests -e virt_infra_state=undefined
 
 DIR="$(dirname "$(readlink -f "${0}")")"
-cd "${DIR}"
 source /etc/os-release
 
 # Check for dependencies
@@ -69,4 +68,4 @@ if ! type ansible-playbook &>/dev/null ; then
 	echo "Continuing with Ansible playbook!"
 fi
 
-exec ansible-playbook ./virt-infra.yml ${@}
+exec ansible-playbook "${DIR}/virt-infra.yml" ${@}


### PR DESCRIPTION
The run script was cd'ing into its directory so that the sample
inventory and ansible.cfg will be found by default. This works great for
testing it, however when executing the run script from another
directory (such as an inventory repo) the inventory can't be relative as
the script changes dir. Furthermore, you can't run a custom ansible.cfg.

So this simple change removes the cd call from the run script so that it
can be run from elsewhere. This does mean that you'll need to specify an
inventory explicity as it won't be found automatically, but that's
probably one of the main reasons to run it from another directory
anyway.