### PR TITLE
add support for similar distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ using defaults.
 
 ```bash
 curl -O https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
+sudo mkdir -p /var/lib/libvirt/images
 sudo mv -iv CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2 /var/lib/libvirt/images/
 
-git clone -b multi-kvmhost --recursive https://github.com/csmart/virt-infra-ansible.git
+git clone --recursive https://github.com/csmart/virt-infra-ansible.git
 cd virt-infra-ansible
 
 ./run.sh --limit kvmhost,simple

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,8 @@ if ! type ansible-playbook &>/dev/null ; then
 		echo "OK, please install it and retry."
 		exit 1
 	fi
-	case "${ID,,}" in
+	DISTRO=${ID_LIKE:-${ID}}
+	case "${DISTRO,,}" in
 		centos)
 			if [[ "${VERSION_ID}" -eq "7" ]] ; then
 				PKG_MGR=yum


### PR DESCRIPTION
Currently the run script only checks for specific distros, using the ID
variable from /etc/os-release.

If we check the ID_LIKE variable first, we can support distros derived
from them, for example, Kali which is like Debian.